### PR TITLE
Fix githuub app token expiry

### DIFF
--- a/src/main/kotlin/no/nav/security/GitHubAppAuth.kt
+++ b/src/main/kotlin/no/nav/security/GitHubAppAuth.kt
@@ -13,34 +13,57 @@ import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter
 import java.io.StringReader
 import java.security.interfaces.RSAPrivateKey
 import java.time.Instant
+import java.time.format.DateTimeFormatter
 import java.util.*
+
+interface GitHubTokenProvider {
+    suspend fun getInstallationToken(): String
+}
 
 class GitHubAppAuth(
     private val appId: String,
     private val privateKeyContent: String,
     private val installationId: String,
-    private val httpClient: HttpClient
-) {
+    private val httpClient: HttpClient,
+) : GitHubTokenProvider {
     private val privateKey: RSAPrivateKey = loadPrivateKey(privateKeyContent)
+    private var cachedToken: String? = null
+    private var tokenExpiresAt: Instant = Instant.MIN
 
-    suspend fun getInstallationToken(): String {
-        val jwt = JWT.create()
-            .withIssuer(appId)
-            .withIssuedAt(Date.from(Instant.now().minusSeconds(60)))
-            .withExpiresAt(Date.from(Instant.now().plusSeconds(600)))
-            .sign(Algorithm.RSA256(null, privateKey))
+    override suspend fun getInstallationToken(): String {
+        if (cachedToken != null && Instant.now().isBefore(tokenExpiresAt.minusSeconds(300))) {
+            return cachedToken!!
+        }
 
-        val response = httpClient.post("https://api.github.com/app/installations/$installationId/access_tokens") {
-            headers {
-                append(HttpHeaders.Accept, "application/vnd.github+json")
-                append(HttpHeaders.Authorization, "Bearer $jwt")
-                append("X-GitHub-Api-Version", "2022-11-28")
-            }
-        }.body<InstallationTokenResponse>()
+        val jwt =
+            JWT
+                .create()
+                .withIssuer(appId)
+                .withIssuedAt(Date.from(Instant.now().minusSeconds(60)))
+                .withExpiresAt(Date.from(Instant.now().plusSeconds(600)))
+                .sign(Algorithm.RSA256(null, privateKey))
 
-        logger.info("Fetched installation token for GitHub App with ID $appId and installation ID $installationId, expires at: (${response.expires_at})")
+        val response =
+            httpClient
+                .post("https://api.github.com/app/installations/$installationId/access_tokens") {
+                    headers {
+                        append(HttpHeaders.Accept, "application/vnd.github+json")
+                        append(HttpHeaders.Authorization, "Bearer $jwt")
+                        append("X-GitHub-Api-Version", "2026-03-10")
+                    }
+                }
+        if (!response.status.isSuccess()) {
+            throw IllegalStateException("Failed to fetch GitHub App installation token: HTTP ${response.status.value}")
+        }
+        val tokenResponse = response.body<InstallationTokenResponse>()
 
-        return response.token
+        cachedToken = tokenResponse.token
+        tokenExpiresAt = Instant.from(DateTimeFormatter.ISO_DATE_TIME.parse(tokenResponse.expires_at))
+        logger.info(
+            "Fetched installation token for GitHub App with ID $appId and installation ID $installationId, expires at: (${tokenResponse.expires_at})",
+        )
+
+        return tokenResponse.token
     }
 
     private fun loadPrivateKey(pemContent: String): RSAPrivateKey {
@@ -50,6 +73,8 @@ class GitHubAppAuth(
     }
 
     @Serializable
-    private data class InstallationTokenResponse(val token: String, val expires_at: String)
+    private data class InstallationTokenResponse(
+        val token: String,
+        val expires_at: String,
+    )
 }
-

--- a/src/main/kotlin/no/nav/security/Github.kt
+++ b/src/main/kotlin/no/nav/security/Github.kt
@@ -5,6 +5,7 @@ import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
+import io.ktor.http.*
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.contentType
@@ -15,9 +16,14 @@ import kotlinx.serialization.json.Json
 import no.nav.security.dto.GithubRepositoriesResponse
 import no.nav.security.dto.GithubVulnerabilitiesResponse
 
-private val json = Json { ignoreUnknownKeys = true; explicitNulls = false }
+private val json =
+    Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+    }
 
-private val fetchGithubRepositoriesQuery = """
+private val fetchGithubRepositoriesQuery =
+    """
     query (${'$'}orgName: String!, ${'$'}repoEndCursor: String) {
       rateLimit { remaining limit resetAt }
       organization(login: ${'$'}orgName) {
@@ -31,9 +37,10 @@ private val fetchGithubRepositoriesQuery = """
         }
       }
     }
-""".trimIndent()
+    """.trimIndent()
 
-private val fetchGithubVulnerabilitiesQuery = """
+private val fetchGithubVulnerabilitiesQuery =
+    """
     query (${'$'}orgName: String!, ${'$'}repoEndCursor: String, ${'$'}repoStartCursor: String, ${'$'}vulnEndCursor: String) {
       rateLimit { remaining limit resetAt }
       organization(login: ${'$'}orgName) {
@@ -62,22 +69,22 @@ private val fetchGithubVulnerabilitiesQuery = """
         }
       }
     }
-""".trimIndent()
+    """.trimIndent()
 
 open class GitHub(
     private val httpClient: HttpClient,
     private val baseUrl: String = "https://api.github.com/graphql",
-    private val rateLimitHandler: RateLimitHandler = RateLimitHandler()
+    private val rateLimitHandler: RateLimitHandler = RateLimitHandler(),
 ) {
-
     open suspend fun fetchOrgRepositories(
         repositoryCursor: String? = null,
-        repositoryListe: List<GithubRepository> = emptyList()
+        repositoryListe: List<GithubRepository> = emptyList(),
     ): List<GithubRepository> {
-        val response: GithubRepositoriesResponse = executeGraphQL(
-            query = fetchGithubRepositoriesQuery,
-            variables = mapOf("orgName" to "navikt", "repoEndCursor" to repositoryCursor)
-        )
+        val response: GithubRepositoriesResponse =
+            executeGraphQL(
+                query = fetchGithubRepositoriesQuery,
+                variables = mapOf("orgName" to "navikt", "repoEndCursor" to repositoryCursor),
+            )
 
         response.errors?.let {
             logger.error("Error fetching repository from GitHub: $it")
@@ -89,22 +96,29 @@ open class GitHub(
                 remaining = rateLimit.remaining,
                 limit = rateLimit.limit,
                 resetAt = rateLimit.resetAt,
-                operationName = "fetchOrgRepositories"
+                operationName = "fetchOrgRepositories",
             )
         }
 
-        val updated = repositoryListe + (response.data?.organization?.repositories?.nodes?.map {
-            GithubRepository(
-                name = it.name,
-                nameWithOwner = it.nameWithOwner,
-                isArchived = it.isArchived,
-                pushedAt = it.pushedAt,
-                hasVulnerabilityAlertsEnabled = it.hasVulnerabilityAlertsEnabled,
-                vulnerabilityAlerts = it.vulnerabilityAlerts?.totalCount ?: 0
+        val updated =
+            repositoryListe + (
+                response.data?.organization?.repositories?.nodes?.map {
+                    GithubRepository(
+                        name = it.name,
+                        nameWithOwner = it.nameWithOwner,
+                        isArchived = it.isArchived,
+                        pushedAt = it.pushedAt,
+                        hasVulnerabilityAlertsEnabled = it.hasVulnerabilityAlertsEnabled,
+                        vulnerabilityAlerts = it.vulnerabilityAlerts?.totalCount ?: 0,
+                    )
+                } ?: emptyList()
             )
-        } ?: emptyList())
 
-        val pageInfo = response.data?.organization?.repositories?.pageInfo
+        val pageInfo =
+            response.data
+                ?.organization
+                ?.repositories
+                ?.pageInfo
         val nextCursor = pageInfo?.endCursor.takeIf { pageInfo?.hasNextPage == true }
 
         return if (nextCursor != null) {
@@ -119,35 +133,42 @@ open class GitHub(
         repoEndCursor: String? = null,
         repoStartCursor: String? = null,
         vulnEndCursor: String? = null,
-        vulnerabilitiesList: List<GithubRepoVulnerabilities> = emptyList()
+        vulnerabilitiesList: List<GithubRepoVulnerabilities> = emptyList(),
     ): List<GithubRepoVulnerabilities> {
         logger.info("Fetching more vulnerabilities, vulnCount: ${vulnerabilitiesList.size}")
 
-        val response: GithubVulnerabilitiesResponse = try {
-            executeGraphQL(
-                query = fetchGithubVulnerabilitiesQuery,
-                variables = mapOf(
-                    "orgName" to "navikt",
-                    "repoEndCursor" to repoEndCursor,
-                    "repoStartCursor" to repoStartCursor,
-                    "vulnEndCursor" to vulnEndCursor
+        val response: GithubVulnerabilitiesResponse =
+            try {
+                executeGraphQL(
+                    query = fetchGithubVulnerabilitiesQuery,
+                    variables =
+                        mapOf(
+                            "orgName" to "navikt",
+                            "repoEndCursor" to repoEndCursor,
+                            "repoStartCursor" to repoStartCursor,
+                            "vulnEndCursor" to vulnEndCursor,
+                        ),
                 )
-            )
-        } catch (e: Exception) {
-            logger.error("Exception during GraphQL execution for vulnerabilities. repoEndCursor=$repoEndCursor, vulnEndCursor=$vulnEndCursor", e)
-            throw e
-        }
+            } catch (e: Exception) {
+                logger.error(
+                    "Exception during GraphQL execution for vulnerabilities. repoEndCursor=$repoEndCursor, vulnEndCursor=$vulnEndCursor",
+                    e,
+                )
+                throw e
+            }
 
         response.errors?.let { errors ->
-            val errorDetails = errors.mapIndexed { index, error ->
-                buildString {
-                    append("\n  Error ${index + 1}:")
-                    append("\n    Message: ${error.message}")
-                    error.path?.let { append("\n    Path: $it") }
-                    error.locations?.let { append("\n    Locations: $it") }
-                    error.extensions?.let { append("\n    Extensions: $it") }
-                }
-            }.joinToString("")
+            val errorDetails =
+                errors
+                    .mapIndexed { index, error ->
+                        buildString {
+                            append("\n  Error ${index + 1}:")
+                            append("\n    Message: ${error.message}")
+                            error.path?.let { append("\n    Path: $it") }
+                            error.locations?.let { append("\n    Locations: $it") }
+                            error.extensions?.let { append("\n    Extensions: $it") }
+                        }
+                    }.joinToString("")
             logger.error("Error fetching vulnerabilities from GitHub (${errors.size} error(s)):$errorDetails")
             throw RuntimeException("Error fetching vulnerabilities from GitHub: ${errors.map { it.message }}")
         }
@@ -157,46 +178,52 @@ open class GitHub(
                 remaining = rateLimit.remaining,
                 limit = rateLimit.limit,
                 resetAt = rateLimit.resetAt,
-                operationName = "fetchRepositoryVulnerabilities"
+                operationName = "fetchRepositoryVulnerabilities",
             )
         }
 
-        val repositories = response.data?.organization?.repositories?.nodes?.mapNotNull { repo ->
-            val vulnerabilities = repo.vulnerabilityAlerts?.nodes?.mapNotNull { alert ->
-                alert.securityVulnerability?.let { secVuln ->
-                    GithubRepoVulnerabilities.GithubVulnerability(
-                        severity = secVuln.severity,
-                        identifier = alert.securityAdvisory?.identifiers?.map { identifier ->
-                            GithubRepoVulnerabilities.GithubVulnerability.GithubVulnerabilityIdentifier(
-                                value = identifier.value,
-                                type = identifier.type
+        val repositories =
+            response.data?.organization?.repositories?.nodes?.mapNotNull { repo ->
+                val vulnerabilities =
+                    repo.vulnerabilityAlerts?.nodes?.mapNotNull { alert ->
+                        alert.securityVulnerability?.let { secVuln ->
+                            GithubRepoVulnerabilities.GithubVulnerability(
+                                severity = secVuln.severity,
+                                identifier =
+                                    alert.securityAdvisory?.identifiers?.map { identifier ->
+                                        GithubRepoVulnerabilities.GithubVulnerability.GithubVulnerabilityIdentifier(
+                                            value = identifier.value,
+                                            type = identifier.type,
+                                        )
+                                    } ?: emptyList(),
+                                dependencyScope = alert.dependencyScope,
+                                dependabotUpdatePullRequestUrl = alert.dependabotUpdate?.pullRequest?.permalink,
+                                publishedAt = alert.securityAdvisory?.publishedAt,
+                                cvssScore = alert.securityAdvisory?.cvss?.score,
+                                summary = alert.securityAdvisory?.summary,
+                                packageEcosystem = secVuln.pkg.ecosystem,
+                                packageName = secVuln.pkg.name,
                             )
-                        } ?: emptyList(),
-                        dependencyScope = alert.dependencyScope,
-                        dependabotUpdatePullRequestUrl = alert.dependabotUpdate?.pullRequest?.permalink,
-                        publishedAt = alert.securityAdvisory?.publishedAt,
-                        cvssScore = alert.securityAdvisory?.cvss?.score,
-                        summary = alert.securityAdvisory?.summary,
-                        packageEcosystem = secVuln.pkg.ecosystem,
-                        packageName = secVuln.pkg.name
+                        }
+                    } ?: emptyList()
+
+                if (vulnerabilities.isNotEmpty()) {
+                    GithubRepoVulnerabilities(
+                        repository = repo.name,
+                        nameWithOwner = repo.nameWithOwner,
+                        vulnerabilities = vulnerabilities,
                     )
+                } else {
+                    null
                 }
             } ?: emptyList()
 
-            if (vulnerabilities.isNotEmpty()) {
-                GithubRepoVulnerabilities(
-                    repository = repo.name,
-                    nameWithOwner = repo.nameWithOwner,
-                    vulnerabilities = vulnerabilities
-                )
-            } else null
-        } ?: emptyList()
-
         val updatedVulnerabilitiesList = mergeGithubRepositories(vulnerabilitiesList, repositories)
 
-        val repoWithMoreVulns = response.data?.organization?.repositories?.nodes?.find { repo ->
-            repo.vulnerabilityAlerts?.pageInfo?.hasNextPage == true
-        }
+        val repoWithMoreVulns =
+            response.data?.organization?.repositories?.nodes?.find { repo ->
+                repo.vulnerabilityAlerts?.pageInfo?.hasNextPage == true
+            }
 
         if (repoWithMoreVulns != null) {
             logger.info("Repository ${repoWithMoreVulns.name} has more vulnerabilities, fetching next page")
@@ -204,11 +231,15 @@ open class GitHub(
                 repoEndCursor = repoEndCursor,
                 repoStartCursor = repoStartCursor,
                 vulnEndCursor = repoWithMoreVulns.vulnerabilityAlerts?.pageInfo?.endCursor,
-                vulnerabilitiesList = updatedVulnerabilitiesList
+                vulnerabilitiesList = updatedVulnerabilitiesList,
             )
         }
 
-        val repoPageInfo = response.data?.organization?.repositories?.pageInfo
+        val repoPageInfo =
+            response.data
+                ?.organization
+                ?.repositories
+                ?.pageInfo
         val nextRepoPage = repoPageInfo?.endCursor.takeIf { repoPageInfo?.hasNextPage == true }
 
         return if (nextRepoPage != null) {
@@ -217,7 +248,7 @@ open class GitHub(
                 repoEndCursor = nextRepoPage,
                 repoStartCursor = null,
                 vulnEndCursor = null,
-                vulnerabilitiesList = updatedVulnerabilitiesList
+                vulnerabilitiesList = updatedVulnerabilitiesList,
             )
         } else {
             updatedVulnerabilitiesList
@@ -226,27 +257,33 @@ open class GitHub(
 
     private suspend inline fun <reified T> executeGraphQL(
         query: String,
-        variables: Map<String, String?>
+        variables: Map<String, String?>,
     ): T {
-        val body = buildString {
-            append("""{"query":""")
-            append(json.encodeToString(query))
-            append(""","variables":{""")
-            variables.entries
-                .filter { it.value != null }
-                .joinTo(this, ",") { (k, v) -> """"$k":${json.encodeToString(v)}""" }
-            append("}}")
+        val body =
+            buildString {
+                append("""{"query":""")
+                append(json.encodeToString(query))
+                append(""","variables":{""")
+                variables.entries
+                    .filter { it.value != null }
+                    .joinTo(this, ",") { (k, v) -> """"$k":${json.encodeToString(v)}""" }
+                append("}}")
+            }
+        val response =
+            httpClient
+                .post(baseUrl) {
+                    contentType(ContentType.Application.Json)
+                    setBody(body)
+                }
+        if (!response.status.isSuccess()) {
+            throw IllegalStateException("GitHub GraphQL API error: HTTP ${response.status.value}")
         }
-        val responseText = httpClient.post(baseUrl) {
-            contentType(ContentType.Application.Json)
-            setBody(body)
-        }.body<String>()
-        return json.decodeFromString(responseText)
+        return json.decodeFromString(response.body())
     }
 
     private fun mergeGithubRepositories(
         existingRepos: List<GithubRepoVulnerabilities>,
-        newRepos: List<GithubRepoVulnerabilities>
+        newRepos: List<GithubRepoVulnerabilities>,
     ): List<GithubRepoVulnerabilities> {
         val repoMap = (existingRepos + newRepos).groupBy { it.repository }
         return repoMap.map { (_, repos) ->
@@ -257,66 +294,71 @@ open class GitHub(
     }
 }
 
-suspend fun List<GithubRepository>.fetchRepositoryAdmins(httpClient: HttpClient, concurrencyLevel: Int = 10): List<GithubRepository> = coroutineScope {
-    var errorCount = 0
-    var successCount = 0
+suspend fun List<GithubRepository>.fetchRepositoryAdmins(
+    httpClient: HttpClient,
+    concurrencyLevel: Int = 10,
+): List<GithubRepository> =
+    coroutineScope {
+        var errorCount = 0
+        var successCount = 0
 
-    val result = chunked(100)
-        .flatMap { chunk ->
-            chunk.map { repo ->
-                async(Dispatchers.IO) {
-                    try {
-                        val response = httpClient
-                            .get("https://api.github.com/repos/navikt/${repo.name}/teams") {
-                                headers {
-                                    append(HttpHeaders.Accept, "application/vnd.github+json")
-                                    append("X-GitHub-Api-Version", "2022-11-28")
+        val result =
+            chunked(100)
+                .flatMap { chunk ->
+                    chunk
+                        .map { repo ->
+                            async(Dispatchers.IO) {
+                                try {
+                                    val response =
+                                        httpClient
+                                            .get("https://api.github.com/repos/navikt/${repo.name}/teams") {
+                                                headers {
+                                                    append(HttpHeaders.Accept, "application/vnd.github+json")
+                                                    append("X-GitHub-Api-Version", "2026-03-10")
+                                                }
+                                            }
+                                    if (!response.status.isSuccess()) {
+                                        throw IllegalStateException(
+                                            "GitHub API error ${response.status.value} fetching teams for ${repo.name}",
+                                        )
+                                    }
+                                    val teams: List<Team> = response.body()
+                                    val adminTeams = teams.filter { it.permission == "admin" }.map { it.name }.toSet()
+
+                                    successCount++
+                                    if (adminTeams.isNotEmpty()) {
+                                        repo.copy(adminTeams = adminTeams)
+                                    } else {
+                                        repo
+                                    }
+                                } catch (e: Exception) {
+                                    errorCount++
+                                    logger.warn("Error fetching teams for ${repo.name}: ${e.message}")
+                                    repo
                                 }
                             }
-                        val teams: List<Team> = response.body()
-                        val adminTeams = teams.filter { it.permission == "admin" }.map { it.name }.toSet()
-
-                        successCount++
-                        if (adminTeams.isNotEmpty()) {
-                            repo.copy(adminTeams = adminTeams)
-                        } else {
-                            repo
-                        }
-                    } catch (e: Exception) {
-                        errorCount++
-                        when {
-                            e.message?.contains("500") == true ->
-                                logger.warn("GitHub API server error (500) fetching teams for ${repo.name}")
-                            e.message?.contains("403") == true || e.message?.contains("429") == true ->
-                                logger.warn("Rate limit error fetching teams for ${repo.name}: ${e.message}")
-                            else ->
-                                logger.warn("Error fetching teams for ${repo.name}: ${e.message}")
-                        }
-                        repo
-                    }
+                        }.windowed(concurrencyLevel, concurrencyLevel, true) { windowOfDeferred ->
+                            runBlocking { windowOfDeferred.awaitAll() }
+                        }.flatten()
                 }
-            }.windowed(concurrencyLevel, concurrencyLevel, true) { windowOfDeferred ->
-                runBlocking { windowOfDeferred.awaitAll() }
-            }.flatten()
+
+        if (errorCount > 0) {
+            logger.info("Fetched admin teams: $successCount successful, $errorCount failed")
         }
 
-    if (errorCount > 0) {
-        logger.info("Fetched admin teams: $successCount successful, $errorCount failed")
+        result
     }
-
-    result
-}
 
 @Serializable
 data class Team(
     val name: String,
-    val permission: String
+    val permission: String,
 )
 
 data class GithubRepoVulnerabilities(
     val repository: String,
     val nameWithOwner: String,
-    val vulnerabilities: List<GithubVulnerability>
+    val vulnerabilities: List<GithubVulnerability>,
 ) {
     data class GithubVulnerability(
         val severity: String,
@@ -327,11 +369,11 @@ data class GithubRepoVulnerabilities(
         val cvssScore: Double? = null,
         val summary: String? = null,
         val packageEcosystem: String? = null,
-        val packageName: String? = null
+        val packageName: String? = null,
     ) {
         data class GithubVulnerabilityIdentifier(
             val value: String,
-            val type: String
+            val type: String,
         )
     }
 }
@@ -343,7 +385,7 @@ data class GithubRepository(
     val pushedAt: DateTime?,
     val hasVulnerabilityAlertsEnabled: Boolean,
     val vulnerabilityAlerts: Int,
-    val adminTeams: Set<String> = emptySet()
+    val adminTeams: Set<String> = emptySet(),
 )
 
 typealias DateTime = String

--- a/src/main/kotlin/no/nav/security/Main.kt
+++ b/src/main/kotlin/no/nav/security/Main.kt
@@ -3,16 +3,15 @@ package no.nav.security
 import io.ktor.client.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.plugins.*
+import io.ktor.client.plugins.HttpSend
 import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.plugins.plugin
 import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.http.HttpHeaders.UserAgent
 import io.ktor.serialization.kotlinx.json.*
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
-import kotlin.math.max
-import kotlin.math.min
-import kotlin.math.pow
 import no.nav.security.bigquery.BQNaisTeam
 import no.nav.security.bigquery.BQRepoStat
 import no.nav.security.bigquery.BigQueryRepos
@@ -25,6 +24,9 @@ import no.nav.security.kafka.KafkaConfig
 import no.nav.security.kafka.KafkaProducer
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.pow
 
 val logger: Logger = LoggerFactory.getLogger("appsec-stats")
 
@@ -36,32 +38,34 @@ data class AppDependencies(
     val bqRepo: BigQueryRepos,
     val bqTeam: BigQueryTeams,
     val bqVulnerabilities: BigQueryVulnerabilities,
-    val kafkaProducer: KafkaProducer
+    val kafkaProducer: KafkaProducer,
 )
 
-fun main(args: Array<String>): Unit = runBlocking {
-    try {
-        val deps = createProductionDependencies()
+fun main(args: Array<String>): Unit =
+    runBlocking {
+        try {
+            val deps = createProductionDependencies()
 
-        if (args.contains("--fetch-vulnerabilities")) {
-            fetchVulnerabilities(deps)
-        } else {
-            fetchRepositoryStats(deps)
+            if (args.contains("--fetch-vulnerabilities")) {
+                fetchVulnerabilities(deps)
+            } else {
+                fetchRepositoryStats(deps)
+            }
+        } catch (e: Exception) {
+            logger.error("Application crashed with error: ${e.message}", e)
+            throw e
         }
-    } catch (e: Exception) {
-        logger.error("Application crashed with error: ${e.message}", e)
-        throw e
     }
-}
 
 suspend fun createProductionDependencies(): AppDependencies {
-    val appAuth = GitHubAppAuth(
-        appId = requiredFromEnv("GITHUB_APP_ID"),
-        privateKeyContent = requiredFromEnv("GITHUB_APP_PRIVATE_KEY").replace("\\n", "\n"),
-        installationId = requiredFromEnv("GITHUB_APP_INSTALLATION_ID"),
-        httpClient = httpClient(null)
-    )
-    val githubHttpClient = httpClient(authToken = appAuth.getInstallationToken())
+    val appAuth =
+        GitHubAppAuth(
+            appId = requiredFromEnv("GITHUB_APP_ID"),
+            privateKeyContent = requiredFromEnv("GITHUB_APP_PRIVATE_KEY").replace("\\n", "\n"),
+            installationId = requiredFromEnv("GITHUB_APP_INSTALLATION_ID"),
+            httpClient = httpClient(authToken = null),
+        )
+    val githubHttpClient = httpClient(tokenProvider = appAuth)
 
     return AppDependencies(
         github = GitHub(httpClient = githubHttpClient),
@@ -71,7 +75,10 @@ suspend fun createProductionDependencies(): AppDependencies {
         bqRepo = BigQueryRepos(requiredFromEnv("GCP_TEAM_PROJECT_ID"), requiredFromEnv("NAIS_ANALYSE_PROJECT_ID")),
         bqTeam = BigQueryTeams(requiredFromEnv("GCP_TEAM_PROJECT_ID")),
         bqVulnerabilities = BigQueryVulnerabilities(requiredFromEnv("GCP_TEAM_PROJECT_ID")),
-        kafkaProducer = KafkaProducer(KafkaConfig.fromEnvironment() ?: throw RuntimeException("Kafka configuration missing in environment"))
+        kafkaProducer =
+            KafkaProducer(
+                KafkaConfig.fromEnvironment() ?: throw RuntimeException("Kafka configuration missing in environment"),
+            ),
     )
 }
 
@@ -82,51 +89,67 @@ internal suspend fun fetchVulnerabilities(deps: AppDependencies) {
     val kafkaProducer = deps.kafkaProducer
 
     logger.info("Fetching vulnerability data from Nais API...")
-    val naisRepositories = try {
-        naisApi.repoVulnerabilities()
-    } catch (e: Exception) {
-        logger.error("Failed to fetch vulnerabilities from Nais API: ${e.message}", e)
-        throw e
-    }
-    logger.info("Fetched vulnerability data for ${naisRepositories.size} repositories for a total of ${naisRepositories.sumOf { it.vulnerabilities.size }} vulnerabilities from Nais API")
+    val naisRepositories =
+        try {
+            naisApi.repoVulnerabilities()
+        } catch (e: Exception) {
+            logger.error("Failed to fetch vulnerabilities from Nais API: ${e.message}", e)
+            throw e
+        }
+    logger.info(
+        "Fetched vulnerability data for ${naisRepositories.size} repositories for a total of ${
+            naisRepositories.sumOf {
+                it.vulnerabilities.size
+            }
+        } vulnerabilities from Nais API",
+    )
 
     logger.info("Fetching vulnerability data from GitHub...")
     val githubVulns = github.fetchRepositoryVulnerabilities()
-    logger.info("Fetched vulnerabilities for ${githubVulns.size} repositories for a total of ${githubVulns.sumOf { it.vulnerabilities.size }} vulnerabilities")
+    logger.info(
+        "Fetched vulnerabilities for ${githubVulns.size} repositories for a total of ${
+            githubVulns.sumOf {
+                it.vulnerabilities.size
+            }
+        } vulnerabilities",
+    )
 
     logger.info("Combining vulnerabilities from both sources...")
     val vulnerabilityCombiner = VulnerabilityCombiner()
     val allVulnerabilities = vulnerabilityCombiner.combineVulnerabilities(naisRepositories, githubVulns)
     logger.info("Combined vulnerabilities for ${allVulnerabilities.size} repositories")
 
-    for(repo in githubVulns) {
-        val message = GithubRepoStats(
-            repositoryName = repo.nameWithOwner,
-            vulnerabilities = repo.vulnerabilities.map { vuln ->
-                GithubRepoStats.VulnerabilityInfo(
-                    severity = vuln.severity,
-                    identifiers = vuln.identifier.map { id ->
-                        GithubRepoStats.VulnerabilityIdentifier(
-                            value = id.value,
-                            type = id.type
+    for (repo in githubVulns) {
+        val message =
+            GithubRepoStats(
+                repositoryName = repo.nameWithOwner,
+                vulnerabilities =
+                    repo.vulnerabilities.map { vuln ->
+                        GithubRepoStats.VulnerabilityInfo(
+                            severity = vuln.severity,
+                            identifiers =
+                                vuln.identifier.map { id ->
+                                    GithubRepoStats.VulnerabilityIdentifier(
+                                        value = id.value,
+                                        type = id.type,
+                                    )
+                                },
+                            dependencyScope = vuln.dependencyScope,
+                            dependabotUpdatePullRequestUrl = vuln.dependabotUpdatePullRequestUrl,
+                            publishedAt = vuln.publishedAt,
+                            cvssScore = vuln.cvssScore,
+                            summary = vuln.summary,
+                            packageEcosystem = vuln.packageEcosystem,
+                            packageName = vuln.packageName,
                         )
                     },
-                    dependencyScope = vuln.dependencyScope,
-                    dependabotUpdatePullRequestUrl = vuln.dependabotUpdatePullRequestUrl,
-                    publishedAt = vuln.publishedAt,
-                    cvssScore = vuln.cvssScore,
-                    summary = vuln.summary,
-                    packageEcosystem = vuln.packageEcosystem,
-                    packageName = vuln.packageName
-                )
-            }
-        ).toJson()
+            ).toJson()
         kafkaProducer.produce(message = message)
     }
 
     bqVulnerabilities.insert(allVulnerabilities).fold(
         { rowCount -> logger.info("Inserted $rowCount rows into BigQuery vulnerabilities dataset") },
-        { ex -> throw ex }
+        { ex -> throw ex },
     )
     logger.info("Vulnerability data fetched and inserted into BigQuery. Exiting application.")
 }
@@ -152,18 +175,31 @@ internal suspend fun fetchRepositoryStats(deps: AppDependencies) {
     val naisTeams = naisApi.teamStats()
     logger.info("Fetched ${naisTeams.size} teams from NAIS with a total of ${naisTeams.sumOf { it.repositories.size }} repositories")
 
-    val repositoriesWithOwners = repositoriesWithAdmins.map { repo ->
-        BQRepoStat(
-            // Add owners from naisTeams AND github repository admins
-            owners = (naisTeams.filter { it.repositories.contains(repo.name) }.map { it.naisTeam } + repo.adminTeams).distinct(),
-            repositoryName = repo.name,
-            vulnerabilityAlertsEnabled = repo.hasVulnerabilityAlertsEnabled,
-            vulnerabilityCount = repo.vulnerabilityAlerts,
-            isArchived = repo.isArchived,
-            lastPush = repo.pushedAt
-        )
-    }
-    logger.info("Found ${repositoriesWithOwners.count { it.owners.isNotEmpty() }} repositories with owners and ${repositoriesWithOwners.count { it.owners.isEmpty() }} repositories with no owners")
+    val repositoriesWithOwners =
+        repositoriesWithAdmins.map { repo ->
+            BQRepoStat(
+                // Add owners from naisTeams AND github repository admins
+                owners = (naisTeams.filter { it.repositories.contains(repo.name) }
+                    .map { it.naisTeam } + repo.adminTeams).distinct(),
+                repositoryName = repo.name,
+                vulnerabilityAlertsEnabled = repo.hasVulnerabilityAlertsEnabled,
+                vulnerabilityCount = repo.vulnerabilityAlerts,
+                isArchived = repo.isArchived,
+                lastPush = repo.pushedAt,
+            )
+        }
+    logger.info(
+        "Found ${
+            repositoriesWithOwners.count {
+                it.owners.isNotEmpty()
+            }
+        } repositories with owners and ${
+            repositoriesWithOwners.count {
+                it.owners
+                    .isEmpty()
+            }
+        } repositories with no owners",
+    )
 
     teamcatalog.updateRecordsWithProductAreasForTeams(repositoriesWithOwners)
 
@@ -194,121 +230,150 @@ internal suspend fun fetchRepositoryStats(deps: AppDependencies) {
 
     bqRepo.insert(repositoriesWithOwners).fold(
         { rowCount -> logger.info("Inserted $rowCount rows into BigQuery repo dataset") },
-        { ex -> throw ex }
+        { ex -> throw ex },
     )
 
     for (repo in githubRepositories) {
-        val message = GithubRepoStats(
-            repositoryName = repo.nameWithOwner,
-            naisTeams = repositoriesWithOwners.find { it.repositoryName == repo.name }?.owners ?: emptyList(),
-        ).toJson()
+        val message =
+            GithubRepoStats(
+                repositoryName = repo.nameWithOwner,
+                naisTeams = repositoriesWithOwners.find { it.repositoryName == repo.name }?.owners ?: emptyList(),
+            ).toJson()
         kafkaProducer.produce(message = message)
     }
 
-    val bqNaisTeams = naisTeams.map {
-        BQNaisTeam(
-            naisTeam = it.naisTeam,
-            slsaCoverage = it.slsaCoverage,
-            hasDeployedResources = it.hasDeployedResources,
-            hasGithubRepositories = it.hasGithubRepositories
-        )
-    }
-    logger.info("Found ${bqNaisTeams.count { it.slsaCoverage == 0 && it.hasDeployedResources }} teams with 0 slsaCoverage and deployed resources")
+    val bqNaisTeams =
+        naisTeams.map {
+            BQNaisTeam(
+                naisTeam = it.naisTeam,
+                slsaCoverage = it.slsaCoverage,
+                hasDeployedResources = it.hasDeployedResources,
+                hasGithubRepositories = it.hasGithubRepositories,
+            )
+        }
+    logger.info(
+        "Found ${bqNaisTeams.count { it.slsaCoverage == 0 && it.hasDeployedResources }} teams with 0 slsaCoverage and deployed resources",
+    )
     bqTeam.insert(bqNaisTeams).fold(
         { rowCount -> logger.info("Inserted $rowCount rows into BigQuery team dataset") },
-        { ex -> throw ex }
+        { ex -> throw ex },
     )
 }
 
-fun newestDeployment(repo: BQRepoStat, deployments: List<BqDeploymentDto>): BqDeploymentDto? =
+fun newestDeployment(
+    repo: BQRepoStat,
+    deployments: List<BqDeploymentDto>,
+): BqDeploymentDto? =
     deployments
         .filter { it.platform.isNotBlank() }
         .filter { it.application == repo.repositoryName }
         .maxByOrNull { it.latestDeploy }
 
-internal fun httpClient(authToken: String?) = HttpClient(CIO) {
-    expectSuccess = false
-    install(HttpTimeout) {
-        requestTimeoutMillis = 120000
-    }
-    install(HttpRequestRetry) {
-        retryOnServerErrors(maxRetries = 3)
-        retryOnException(maxRetries = 3, retryOnTimeout = true)
-        exponentialDelay(base = 2.0, maxDelayMs = 30000)
-
-        // GitHub-specific retry condition
-        // https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api
-        retryIf { request, response ->
-            // Always retry on 403 or 429 status codes (rate limits)
-            // Primary rate limit: x-ratelimit-remaining == "0"
-            // Secondary rate limit: may include retry-after header or just return 403/429
-            val isRateLimit = response.status.value == 403 || response.status.value == 429
-
-            if (isRateLimit) {
-                val remaining = response.headers["x-ratelimit-remaining"]
-                val limit = response.headers["x-ratelimit-limit"]
-                val reset = response.headers["x-ratelimit-reset"]
-                val retryAfter = response.headers["retry-after"]
-                logger.warn(
-                    "REST API rate limit detected: status=${response.status.value}, " +
-                    "remaining=$remaining, limit=$limit, reset=$reset, retry-after=$retryAfter, " +
-                    "url=${request.url}"
-                )
+internal fun httpClient(
+    authToken: String? = null,
+    tokenProvider: GitHubTokenProvider? = null,
+): HttpClient {
+    val client =
+        HttpClient(CIO) {
+            expectSuccess = false
+            install(HttpTimeout) {
+                requestTimeoutMillis = 120000
             }
+            install(HttpRequestRetry) {
+                retryOnServerErrors(maxRetries = 3)
+                retryOnException(maxRetries = 3, retryOnTimeout = true)
+                exponentialDelay(base = 2.0, maxDelayMs = 30000)
 
-            val isServerError = response.status.value >= 500
-            if (isServerError) {
-                logger.warn("Server error detected: status=${response.status.value}, url=${request.url}")
-            }
-            
-            isRateLimit || isServerError
-        }
+                // GitHub-specific retry condition
+                // https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api
+                retryIf { request, response ->
+                    // Always retry on 403 or 429 status codes (rate limits)
+                    // Primary rate limit: x-ratelimit-remaining == "0"
+                    // Secondary rate limit: may include retry-after header or just return 403/429
+                    val isRateLimit = response.status.value == 403 || response.status.value == 429
 
-        // GitHub-specific delay handling
-        delayMillis { retry ->
-            val response = response
-            when {
-                // Primary rate limit: wait until reset time
-                response?.headers?.get("x-ratelimit-remaining") == "0" -> {
-                    val resetTime = response.headers["x-ratelimit-reset"]?.toLongOrNull()
-                    if (resetTime != null) {
-                        val currentTime = System.currentTimeMillis() / 1000
-                        val waitTime = (resetTime - currentTime + 5) * 1000 // Add 5s buffer
-                        max(waitTime, 60000L) // Minimum 1 minute
-                    } else {
-                        300000L // Default 5 minutes
+                    if (isRateLimit) {
+                        val remaining = response.headers["x-ratelimit-remaining"]
+                        val limit = response.headers["x-ratelimit-limit"]
+                        val reset = response.headers["x-ratelimit-reset"]
+                        val retryAfter = response.headers["retry-after"]
+                        logger.warn(
+                            "REST API rate limit detected: status=${response.status.value}, " +
+                                    "remaining=$remaining, limit=$limit, reset=$reset, retry-after=$retryAfter, " +
+                                    "url=${request.url}",
+                        )
+                    }
+
+                    val isServerError = response.status.value >= 500
+                    if (isServerError) {
+                        logger.warn("Server error detected: status=${response.status.value}, url=${request.url}")
+                    }
+
+                    isRateLimit || isServerError
+                }
+
+                // GitHub-specific delay handling
+                delayMillis { retry ->
+                    val response = response
+                    when {
+                        // Primary rate limit: wait until reset time
+                        response?.headers?.get("x-ratelimit-remaining") == "0" -> {
+                            val resetTime = response.headers["x-ratelimit-reset"]?.toLongOrNull()
+                            if (resetTime != null) {
+                                val currentTime = System.currentTimeMillis() / 1000
+                                val waitTime = (resetTime - currentTime + 5) * 1000 // Add 5s buffer
+                                max(waitTime, 60000L) // Minimum 1 minute
+                            } else {
+                                300000L // Default 5 minutes
+                            }
+                        }
+
+                        // Secondary rate limit with retry-after
+                        response?.headers?.get("retry-after") != null -> {
+                            val retryAfter = response.headers["retry-after"]?.toLongOrNull() ?: 60L
+                            (retryAfter + 1) * 1000L // Add 1s buffer
+                        }
+
+                        // Secondary rate limit without retry-after: exponential backoff starting at 1 minute
+                        response?.status?.value == 403 || response?.status?.value == 429 -> {
+                            val baseWait = 60000L // 1 minute
+                            val exponentialWait = (baseWait * 2.0.pow(retry.toDouble())).toLong()
+                            min(exponentialWait, 600000L) // Cap at 10 minutes
+                        }
+
+                        // Standard exponential backoff for other errors
+                        else -> {
+                            (2000L * (retry + 1))
+                        }
                     }
                 }
-                // Secondary rate limit with retry-after
-                response?.headers?.get("retry-after") != null -> {
-                    val retryAfter = response.headers["retry-after"]?.toLongOrNull() ?: 60L
-                    (retryAfter + 1) * 1000L // Add 1s buffer
+            }
+            install(ContentNegotiation) {
+                json(
+                    json =
+                        Json {
+                            explicitNulls = false
+                            ignoreUnknownKeys = true
+                        },
+                )
+            }
+            defaultRequest {
+                headers {
+                    header(HttpHeaders.Accept, ContentType.Application.Json)
+                    header(HttpHeaders.ContentType, ContentType.Application.Json)
+                    authToken?.let { header(HttpHeaders.Authorization, "Bearer $it") }
+                    header(UserAgent, "appsec-stats")
                 }
-                // Secondary rate limit without retry-after: exponential backoff starting at 1 minute
-                response?.status?.value == 403 || response?.status?.value == 429 -> {
-                    val baseWait = 60000L // 1 minute
-                    val exponentialWait = (baseWait * 2.0.pow(retry.toDouble())).toLong()
-                    min(exponentialWait, 600000L) // Cap at 10 minutes
-                }
-                // Standard exponential backoff for other errors
-                else -> (2000L * (retry + 1))
             }
         }
-    }
-    install(ContentNegotiation) {
-        json(json = Json {
-            explicitNulls = false
-            ignoreUnknownKeys = true
-        })
-    }
-    defaultRequest {
-        headers {
-            header(HttpHeaders.Accept, ContentType.Application.Json)
-            header(HttpHeaders.ContentType, ContentType.Application.Json)
-            authToken?.let { header(HttpHeaders.Authorization, "Bearer $authToken") }
-            header(UserAgent, "appsec-stats")
+    if (tokenProvider != null) {
+        client.plugin(HttpSend).intercept { request ->
+            request.headers.remove(HttpHeaders.Authorization)
+            request.headers.append(HttpHeaders.Authorization, "Bearer ${tokenProvider.getInstallationToken()}")
+            execute(request)
         }
     }
+    return client
 }
 
 internal fun requiredFromEnv(name: String) =

--- a/src/main/kotlin/no/nav/security/NaisApi.kt
+++ b/src/main/kotlin/no/nav/security/NaisApi.kt
@@ -5,6 +5,7 @@ import io.ktor.client.call.body
 import io.ktor.client.plugins.*
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
+import io.ktor.http.*
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
 import kotlinx.coroutines.delay
@@ -19,13 +20,15 @@ import no.nav.security.dto.NaisRepoVulnResponse
 import no.nav.security.dto.NaisRepositoryConnection
 import no.nav.security.dto.NaisTeamStatsResponse
 
-private val naisJson = Json {
-    ignoreUnknownKeys = true
-    explicitNulls = false
-    classDiscriminator = "__typename"
-}
+private val naisJson =
+    Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+        classDiscriminator = "__typename"
+    }
 
-private val teamStatsQuery = """
+private val teamStatsQuery =
+    """
     query (${'$'}teamsCursor: Cursor, ${'$'}repoCursor: Cursor) {
       teams(first: 10, after: ${'$'}teamsCursor) {
         nodes {
@@ -40,15 +43,17 @@ private val teamStatsQuery = """
         pageInfo { hasNextPage startCursor endCursor }
       }
     }
-""".trimIndent()
+    """.trimIndent()
 
-private val environmentsQuery = """
+private val environmentsQuery =
+    """
     query Environments {
       environments { nodes { name } }
     }
-""".trimIndent()
+    """.trimIndent()
 
-private val deploymentsQuery = """
+private val deploymentsQuery =
+    """
     query (${'$'}environment: String!, ${'$'}workloadCursor: Cursor) {
       environment(name: ${'$'}environment) {
         workloads(first: 100, after: ${'$'}workloadCursor, orderBy: { field: DEPLOYMENT_TIME, direction: DESC }) {
@@ -61,9 +66,10 @@ private val deploymentsQuery = """
         }
       }
     }
-""".trimIndent()
+    """.trimIndent()
 
-private val repoVulnerabilityQuery = """
+private val repoVulnerabilityQuery =
+    """
     query (${'$'}teamsCursor: Cursor, ${'$'}vulnCursor: Cursor, ${'$'}workloadCursor: Cursor) {
       teams(first: 1, after: ${'$'}teamsCursor, filter: {hasWorkloads:true}) {
         pageInfo { hasNextPage startCursor endCursor }
@@ -97,9 +103,11 @@ private val repoVulnerabilityQuery = """
         }
       }
     }
-""".trimIndent()
+    """.trimIndent()
 
-open class NaisApi(private val httpClient: HttpClient) {
+open class NaisApi(
+    private val httpClient: HttpClient,
+) {
     private val baseUrl = "https://console.nav.cloud.nais.io/graphql"
 
     open suspend fun teamStats(): Set<NaisTeam> = fetchAllTeamStats()
@@ -107,9 +115,10 @@ open class NaisApi(private val httpClient: HttpClient) {
     open suspend fun deployments(): Set<NaisDeployment> {
         val environments = fetchEnvironments()
         logger.info("Fetched ${environments.size} environment profiles: ${environments.joinToString(", ")}")
-        return environments.flatMap { environment ->
-            fetchDeployments(environment)
-        }.toSet()
+        return environments
+            .flatMap { environment ->
+                fetchDeployments(environment)
+            }.toSet()
     }
 
     open suspend fun repoVulnerabilities(): Set<NaisRepository> = fetchRepoVulnerabilities()
@@ -124,25 +133,31 @@ open class NaisApi(private val httpClient: HttpClient) {
             response.data?.teams?.nodes?.forEach { team ->
                 val teamRepositories = fetchAllRepositoriesForTeam(team.repositories)
                 val existingTeam = allTeams[team.slug]
-                allTeams[team.slug] = NaisTeam(
-                    naisTeam = team.slug,
-                    slsaCoverage = team.vulnerabilitySummary.coverage.toInt(),
-                    hasDeployedResources = (team.workloads.pageInfo.totalCount > 0),
-                    hasGithubRepositories = teamRepositories.isNotEmpty(),
-                    repositories = (existingTeam?.repositories ?: emptyList()) + teamRepositories
-                )
+                allTeams[team.slug] =
+                    NaisTeam(
+                        naisTeam = team.slug,
+                        slsaCoverage = team.vulnerabilitySummary.coverage.toInt(),
+                        hasDeployedResources = (team.workloads.pageInfo.totalCount > 0),
+                        hasGithubRepositories = teamRepositories.isNotEmpty(),
+                        repositories = (existingTeam?.repositories ?: emptyList()) + teamRepositories,
+                    )
             }
-            hasNextPage = response.data?.teams?.pageInfo?.hasNextPage ?: false
+            hasNextPage = response.data
+                ?.teams
+                ?.pageInfo
+                ?.hasNextPage ?: false
             if (hasNextPage) {
-                teamCursor = response.data?.teams?.pageInfo?.endCursor
+                teamCursor =
+                    response.data
+                        ?.teams
+                        ?.pageInfo
+                        ?.endCursor
             }
         }
         return allTeams.values.toSet()
     }
 
-    private suspend fun fetchAllRepositoriesForTeam(
-        initialRepoConnection: NaisRepositoryConnection
-    ): List<String> {
+    private suspend fun fetchAllRepositoriesForTeam(initialRepoConnection: NaisRepositoryConnection): List<String> {
         val repositories = mutableListOf<String>()
         repositories.addAll(initialRepoConnection.nodes.map { it.name.substringAfter("/") })
 
@@ -151,7 +166,11 @@ open class NaisApi(private val httpClient: HttpClient) {
 
         while (hasNextRepoPage) {
             val response = executeTeamStatsQuery(null, repoCursor)
-            val teamNode = response.data?.teams?.nodes?.firstOrNull()
+            val teamNode =
+                response.data
+                    ?.teams
+                    ?.nodes
+                    ?.firstOrNull()
             if (teamNode != null) {
                 repositories.addAll(teamNode.repositories.nodes.map { it.name.substringAfter("/") })
                 hasNextRepoPage = teamNode.repositories.pageInfo.hasNextPage
@@ -167,62 +186,82 @@ open class NaisApi(private val httpClient: HttpClient) {
 
     private suspend fun executeTeamStatsQuery(
         teamCursor: String?,
-        repoCursor: String?
+        repoCursor: String?,
     ): NaisTeamStatsResponse {
-        val response = executeGraphQL<NaisTeamStatsResponse>(
-            query = teamStatsQuery,
-            variables = mapOf("teamsCursor" to teamCursor, "repoCursor" to repoCursor)
-        )
+        val response =
+            executeGraphQL<NaisTeamStatsResponse>(
+                query = teamStatsQuery,
+                variables = mapOf("teamsCursor" to teamCursor, "repoCursor" to repoCursor),
+            )
         if (response.errors?.isNotEmpty() == true) {
             throw RuntimeException(
-                "Error fetching team stats from NAIS API (teamCursor: $teamCursor, repoCursor: $repoCursor): ${response.errors}"
+                "Error fetching team stats from NAIS API (teamCursor: $teamCursor, repoCursor: $repoCursor): ${response.errors}",
             )
         }
         return response
     }
 
     private suspend fun fetchEnvironments(): Set<String> {
-        val response = executeGraphQL<NaisEnvironmentsResponse>(
-            query = environmentsQuery,
-            variables = emptyMap()
-        )
-        return response.data?.environments?.nodes?.map { it.name }?.toSet() ?: emptySet()
+        val response =
+            executeGraphQL<NaisEnvironmentsResponse>(
+                query = environmentsQuery,
+                variables = emptyMap(),
+            )
+        return response.data
+            ?.environments
+            ?.nodes
+            ?.map { it.name }
+            ?.toSet() ?: emptySet()
     }
 
     private tailrec suspend fun fetchDeployments(
         environment: String,
         workloadCursor: String? = null,
-        deployments: Set<NaisDeployment> = emptySet()
+        deployments: Set<NaisDeployment> = emptySet(),
     ): Set<NaisDeployment> {
-        val response = executeGraphQL<NaisDeploymentsResponse>(
-            query = deploymentsQuery,
-            variables = mapOf("environment" to environment, "workloadCursor" to workloadCursor)
-        )
+        val response =
+            executeGraphQL<NaisDeploymentsResponse>(
+                query = deploymentsQuery,
+                variables = mapOf("environment" to environment, "workloadCursor" to workloadCursor),
+            )
 
         if (response.data == null) return deployments
 
-        val newDeployments = response.data.environment?.workloads?.nodes?.flatMap { workload ->
-            when (workload) {
-                is NaisDeploymentApplication -> workload.deployments.nodes.mapNotNull { deployment ->
-                    val repo = deployment.repository?.takeIf { it.isNotEmpty() } ?: return@mapNotNull null
-                    val createdAt = deployment.createdAt ?: return@mapNotNull null
-                    NaisDeployment(environment = environment, repository = repo, createdAt = createdAt)
-                }
-                is NaisDeploymentJob -> workload.deployments.nodes.mapNotNull { deployment ->
-                    val repo = deployment.repository?.takeIf { it.isNotEmpty() } ?: return@mapNotNull null
-                    val createdAt = deployment.createdAt ?: return@mapNotNull null
-                    NaisDeployment(environment = environment, repository = repo, createdAt = createdAt)
-                }
-            }
-        }?.toSet() ?: emptySet()
+        val newDeployments =
+            response.data.environment
+                ?.workloads
+                ?.nodes
+                ?.flatMap { workload ->
+                    when (workload) {
+                        is NaisDeploymentApplication -> {
+                            workload.deployments.nodes.mapNotNull { deployment ->
+                                val repo = deployment.repository?.takeIf { it.isNotEmpty() } ?: return@mapNotNull null
+                                val createdAt = deployment.createdAt ?: return@mapNotNull null
+                                NaisDeployment(environment = environment, repository = repo, createdAt = createdAt)
+                            }
+                        }
+
+                        is NaisDeploymentJob -> {
+                            workload.deployments.nodes.mapNotNull { deployment ->
+                                val repo = deployment.repository?.takeIf { it.isNotEmpty() } ?: return@mapNotNull null
+                                val createdAt = deployment.createdAt ?: return@mapNotNull null
+                                NaisDeployment(environment = environment, repository = repo, createdAt = createdAt)
+                            }
+                        }
+                    }
+                }?.toSet() ?: emptySet()
 
         val updatedDeployments = deployments + newDeployments
 
-        return if (response.data.environment?.workloads?.pageInfo?.hasNextPage == true) {
+        return if (response.data.environment
+                ?.workloads
+                ?.pageInfo
+                ?.hasNextPage == true
+        ) {
             fetchDeployments(
                 environment,
                 response.data.environment.workloads.pageInfo.endCursor,
-                updatedDeployments
+                updatedDeployments,
             )
         } else {
             updatedDeployments
@@ -233,13 +272,15 @@ open class NaisApi(private val httpClient: HttpClient) {
         teamCursor: String? = null,
         workloadCursor: String? = null,
         vulnCursor: String? = null,
-        repos: Set<NaisRepository> = emptySet()
+        repos: Set<NaisRepository> = emptySet(),
     ): Set<NaisRepository> {
         logger.info("Fetching repo vulnerabilities (teamCursor: $teamCursor, workloadCursor: $workloadCursor, vulnCursor: $vulnCursor)")
         val response = executeWithRetry(teamCursor, workloadCursor, vulnCursor)
 
         if (response.errors?.isNotEmpty() == true) {
-            logger.error("GraphQL errors in fetchRepoVulnerabilities (teamCursor: $teamCursor, workloadCursor: $workloadCursor, vulnCursor: $vulnCursor)")
+            logger.error(
+                "GraphQL errors in fetchRepoVulnerabilities (teamCursor: $teamCursor, workloadCursor: $workloadCursor, vulnCursor: $vulnCursor)",
+            )
             response.errors.forEachIndexed { index, error ->
                 try {
                     logger.error("Error[$index]: message='${error.message}', path=${error.path}, locations=${error.locations}")
@@ -248,52 +289,61 @@ open class NaisApi(private val httpClient: HttpClient) {
                 }
             }
             logger.error("Stopping processing. Resume with: teamCursor=$teamCursor, workloadCursor=$workloadCursor, vulnCursor=$vulnCursor")
-            throw RuntimeException("Error fetching workloads stats from Nais API at teamCursor=$teamCursor, workloadCursor=$workloadCursor, vulnCursor=$vulnCursor. Check logs for error details.")
+            throw RuntimeException(
+                "Error fetching workloads stats from Nais API at teamCursor=$teamCursor, workloadCursor=$workloadCursor, vulnCursor=$vulnCursor. Check logs for error details.",
+            )
         }
 
         val data = response.data ?: return repos
 
-        val newRepos = data.teams.nodes.flatMap { team ->
-            team.workloads.nodes.mapNotNull { workload ->
-                when (workload) {
-                    is NaisRepoVulnApplication -> processWorkloadVulnerabilities(workload.name, workload.image, repos)
-                    is NaisRepoVulnJob -> processWorkloadVulnerabilities(workload.name, workload.image, repos)
-                }
-            }
-        }.toSet()
+        val newRepos =
+            data.teams.nodes
+                .flatMap { team ->
+                    team.workloads.nodes.mapNotNull { workload ->
+                        when (workload) {
+                            is NaisRepoVulnApplication -> processWorkloadVulnerabilities(workload.name, workload.image, repos)
+                            is NaisRepoVulnJob -> processWorkloadVulnerabilities(workload.name, workload.image, repos)
+                        }
+                    }
+                }.toSet()
 
         val updatedRepos = mergeRepositories(repos, newRepos)
 
-        val workloadWithMoreVulns = data.teams.nodes.asSequence()
-            .flatMap { team -> team.workloads.nodes.asSequence() }
-            .firstOrNull { workload ->
-                when (workload) {
-                    is NaisRepoVulnApplication -> workload.image.vulnerabilities.pageInfo.hasNextPage
-                    is NaisRepoVulnJob -> workload.image.vulnerabilities.pageInfo.hasNextPage
+        val workloadWithMoreVulns =
+            data.teams.nodes
+                .asSequence()
+                .flatMap { team -> team.workloads.nodes.asSequence() }
+                .firstOrNull { workload ->
+                    when (workload) {
+                        is NaisRepoVulnApplication -> workload.image.vulnerabilities.pageInfo.hasNextPage
+                        is NaisRepoVulnJob -> workload.image.vulnerabilities.pageInfo.hasNextPage
+                    }
                 }
-            }
 
         if (workloadWithMoreVulns != null) {
-            val vulnEndCursor = when (workloadWithMoreVulns) {
-                is NaisRepoVulnApplication -> workloadWithMoreVulns.image.vulnerabilities.pageInfo.endCursor
-                is NaisRepoVulnJob -> workloadWithMoreVulns.image.vulnerabilities.pageInfo.endCursor
-            }
-            val workloadName = when (workloadWithMoreVulns) {
-                is NaisRepoVulnApplication -> workloadWithMoreVulns.name
-                is NaisRepoVulnJob -> workloadWithMoreVulns.name
-            }
+            val vulnEndCursor =
+                when (workloadWithMoreVulns) {
+                    is NaisRepoVulnApplication -> workloadWithMoreVulns.image.vulnerabilities.pageInfo.endCursor
+                    is NaisRepoVulnJob -> workloadWithMoreVulns.image.vulnerabilities.pageInfo.endCursor
+                }
+            val workloadName =
+                when (workloadWithMoreVulns) {
+                    is NaisRepoVulnApplication -> workloadWithMoreVulns.name
+                    is NaisRepoVulnJob -> workloadWithMoreVulns.name
+                }
             logger.info("Workload '$workloadName' has more vulnerabilities (cursor: $vulnEndCursor). Fetching next page.")
             return fetchRepoVulnerabilities(
                 teamCursor = teamCursor,
                 workloadCursor = workloadCursor,
                 vulnCursor = vulnEndCursor,
-                repos = updatedRepos
+                repos = updatedRepos,
             )
         }
 
-        val teamWithMoreWorkloads = data.teams.nodes.firstOrNull { team ->
-            team.workloads.pageInfo.hasNextPage
-        }
+        val teamWithMoreWorkloads =
+            data.teams.nodes.firstOrNull { team ->
+                team.workloads.pageInfo.hasNextPage
+            }
 
         if (teamWithMoreWorkloads != null) {
             logger.info("Team has more workloads (cursor: ${teamWithMoreWorkloads.workloads.pageInfo.endCursor}). Fetching next page.")
@@ -301,7 +351,7 @@ open class NaisApi(private val httpClient: HttpClient) {
                 teamCursor = teamCursor,
                 workloadCursor = teamWithMoreWorkloads.workloads.pageInfo.endCursor,
                 vulnCursor = null,
-                repos = updatedRepos
+                repos = updatedRepos,
             )
         }
 
@@ -311,7 +361,7 @@ open class NaisApi(private val httpClient: HttpClient) {
                 teamCursor = data.teams.pageInfo.endCursor,
                 workloadCursor = null,
                 vulnCursor = null,
-                repos = updatedRepos
+                repos = updatedRepos,
             )
         } else {
             logger.info("Pagination complete. Total repositories with vulnerabilities: ${updatedRepos.size}")
@@ -323,55 +373,65 @@ open class NaisApi(private val httpClient: HttpClient) {
         teamCursor: String?,
         workloadCursor: String?,
         vulnCursor: String?,
-        maxRetries: Int = 3
+        maxRetries: Int = 3,
     ): NaisRepoVulnResponse {
         var lastException: Exception? = null
         repeat(maxRetries) { attempt ->
             try {
                 return executeGraphQL(
                     query = repoVulnerabilityQuery,
-                    variables = mapOf(
-                        "teamsCursor" to teamCursor,
-                        "workloadCursor" to workloadCursor,
-                        "vulnCursor" to vulnCursor
-                    )
+                    variables =
+                        mapOf(
+                            "teamsCursor" to teamCursor,
+                            "workloadCursor" to workloadCursor,
+                            "vulnCursor" to vulnCursor,
+                        ),
                 )
             } catch (e: HttpRequestTimeoutException) {
                 lastException = e
                 val delayMs = 10000L * (attempt + 1)
-                logger.warn("Timeout on attempt ${attempt + 1}/$maxRetries for RepoVulnerabilityQuery (teamCursor: $teamCursor, workloadCursor: $workloadCursor, vulnCursor: $vulnCursor). Retrying in ${delayMs}ms.")
+                logger.warn(
+                    "Timeout on attempt ${attempt + 1}/$maxRetries for RepoVulnerabilityQuery (teamCursor: $teamCursor, workloadCursor: $workloadCursor, vulnCursor: $vulnCursor). Retrying in ${delayMs}ms.",
+                )
                 delay(delayMs)
             } catch (e: Exception) {
-                logger.error("Exception executing RepoVulnerabilityQuery (teamCursor: $teamCursor, workloadCursor: $workloadCursor, vulnCursor: $vulnCursor): ${e.message}", e)
+                logger.error(
+                    "Exception executing RepoVulnerabilityQuery (teamCursor: $teamCursor, workloadCursor: $workloadCursor, vulnCursor: $vulnCursor): ${e.message}",
+                    e,
+                )
                 throw RuntimeException(
-                    "Error executing RepoVulnerabilityQuery (teamCursor: $teamCursor, workloadCursor: $workloadCursor, vulnCursor: $vulnCursor): ${e.message}", e
+                    "Error executing RepoVulnerabilityQuery (teamCursor: $teamCursor, workloadCursor: $workloadCursor, vulnCursor: $vulnCursor): ${e.message}",
+                    e,
                 )
             }
         }
         throw RuntimeException(
-            "Error executing RepoVulnerabilityQuery after $maxRetries attempts (teamCursor: $teamCursor, workloadCursor: $workloadCursor, vulnCursor: $vulnCursor): ${lastException?.message}", lastException
+            "Error executing RepoVulnerabilityQuery after $maxRetries attempts (teamCursor: $teamCursor, workloadCursor: $workloadCursor, vulnCursor: $vulnCursor): ${lastException?.message}",
+            lastException,
         )
     }
 
     private fun processWorkloadVulnerabilities(
         workloadName: String,
         image: no.nav.security.dto.NaisContainerImage,
-        repos: Set<NaisRepository>
+        repos: Set<NaisRepository>,
     ): NaisRepository? {
         val repositoryName = workloadName.substringAfter("/")
         val existingVulnerabilities = repos.find { it.name == repositoryName }?.vulnerabilities ?: emptySet()
-        val newVulnerabilities = image.vulnerabilities.nodes.map { vuln ->
-            NaisVulnerability(
-                identifier = vuln.identifier,
-                severity = vuln.severity,
-                suppressed = vuln.suppression != null
-            )
-        }.toSet()
+        val newVulnerabilities =
+            image.vulnerabilities.nodes
+                .map { vuln ->
+                    NaisVulnerability(
+                        identifier = vuln.identifier,
+                        severity = vuln.severity,
+                        suppressed = vuln.suppression != null,
+                    )
+                }.toSet()
 
         return if (newVulnerabilities.isNotEmpty()) {
             NaisRepository(
                 name = repositoryName,
-                vulnerabilities = existingVulnerabilities + newVulnerabilities
+                vulnerabilities = existingVulnerabilities + newVulnerabilities,
             )
         } else {
             repos.find { it.name == repositoryName }
@@ -380,34 +440,40 @@ open class NaisApi(private val httpClient: HttpClient) {
 
     private fun mergeRepositories(
         existingRepos: Set<NaisRepository>,
-        newRepos: Set<NaisRepository>
+        newRepos: Set<NaisRepository>,
     ): Set<NaisRepository> {
         val repoMap = (existingRepos + newRepos).groupBy { it.name }
-        return repoMap.map { (_, repos) ->
-            repos.reduce { acc, repo ->
-                acc.copy(vulnerabilities = acc.vulnerabilities + repo.vulnerabilities)
-            }
-        }.toSet()
+        return repoMap
+            .map { (_, repos) ->
+                repos.reduce { acc, repo ->
+                    acc.copy(vulnerabilities = acc.vulnerabilities + repo.vulnerabilities)
+                }
+            }.toSet()
     }
 
     private suspend inline fun <reified T> executeGraphQL(
         query: String,
-        variables: Map<String, String?>
+        variables: Map<String, String?>,
     ): T {
-        val body = buildString {
-            append("""{"query":""")
-            append(naisJson.encodeToString(query))
-            append(""","variables":{""")
-            variables.entries
-                .filter { it.value != null }
-                .joinTo(this, ",") { (k, v) -> """"$k":${naisJson.encodeToString(v)}""" }
-            append("}}")
+        val body =
+            buildString {
+                append("""{"query":""")
+                append(naisJson.encodeToString(query))
+                append(""","variables":{""")
+                variables.entries
+                    .filter { it.value != null }
+                    .joinTo(this, ",") { (k, v) -> """"$k":${naisJson.encodeToString(v)}""" }
+                append("}}")
+            }
+        val response =
+            httpClient.post(baseUrl) {
+                contentType(ContentType.Application.Json)
+                setBody(body)
+            }
+        if (!response.status.isSuccess()) {
+            throw IllegalStateException("NAIS GraphQL API error: HTTP ${response.status.value}")
         }
-        val responseText = httpClient.post(baseUrl) {
-            contentType(ContentType.Application.Json)
-            setBody(body)
-        }.body<String>()
-        return naisJson.decodeFromString(responseText)
+        return naisJson.decodeFromString(response.body())
     }
 }
 
@@ -427,7 +493,7 @@ data class NaisTeam(
 
 data class NaisRepository(
     val name: String,
-    val vulnerabilities: Set<NaisVulnerability>
+    val vulnerabilities: Set<NaisVulnerability>,
 )
 
 data class NaisVulnerability(

--- a/src/test/kotlin/no/nav/security/GitHubAppAuthTest.kt
+++ b/src/test/kotlin/no/nav/security/GitHubAppAuthTest.kt
@@ -1,0 +1,101 @@
+package no.nav.security
+
+import io.ktor.client.*
+import io.ktor.client.engine.mock.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.http.*
+import io.ktor.serialization.kotlinx.json.*
+import io.ktor.utils.io.*
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import java.io.StringWriter
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+
+private val testKeyPair: KeyPair = KeyPairGenerator.getInstance("RSA").apply { initialize(2048) }.generateKeyPair()
+
+private fun testPrivateKeyPem(): String {
+    val writer = StringWriter()
+    JcaPEMWriter(writer).use { it.writeObject(testKeyPair) }
+    return writer.toString()
+}
+
+class GitHubAppAuthTest {
+    private val futureExpiry = DateTimeFormatter.ISO_INSTANT.format(Instant.now().plusSeconds(3600))
+    private val expiredExpiry = DateTimeFormatter.ISO_INSTANT.format(Instant.now().minusSeconds(3600))
+    private val almostExpiredExpiry = DateTimeFormatter.ISO_INSTANT.format(Instant.now().plusSeconds(60))
+
+    private fun mockClient(vararg tokens: Pair<String, String>): Pair<HttpClient, () -> Int> {
+        var callCount = 0
+        val responses = tokens.toList()
+        val client =
+            HttpClient(
+                MockEngine { _ ->
+                    val (token, expiry) = responses[callCount++]
+                    respond(
+                        content = ByteReadChannel("""{"token":"$token","expires_at":"$expiry"}"""),
+                        status = HttpStatusCode.Created,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                    )
+                },
+            ) {
+                install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+            }
+        return client to { callCount }
+    }
+
+    private fun auth(client: HttpClient) =
+        GitHubAppAuth(
+            appId = "app-id",
+            privateKeyContent = testPrivateKeyPem(),
+            installationId = "install-id",
+            httpClient = client,
+        )
+
+    @Test
+    fun `returns cached token when still valid`() =
+        runBlocking {
+            val (client, callCount) = mockClient("token-1" to futureExpiry, "token-2" to futureExpiry)
+            val appAuth = auth(client)
+
+            val first = appAuth.getInstallationToken()
+            val second = appAuth.getInstallationToken()
+
+            assertEquals("token-1", first)
+            assertEquals("token-1", second)
+            assertEquals(1, callCount())
+        }
+
+    @Test
+    fun `refreshes token when expired`() =
+        runBlocking {
+            val (client, callCount) = mockClient("token-1" to expiredExpiry, "token-2" to futureExpiry)
+            val appAuth = auth(client)
+
+            val first = appAuth.getInstallationToken()
+            val second = appAuth.getInstallationToken()
+
+            assertEquals("token-1", first)
+            assertEquals("token-2", second)
+            assertEquals(2, callCount())
+        }
+
+    @Test
+    fun `refreshes token when within 5 minute buffer`() =
+        runBlocking {
+            val (client, callCount) = mockClient("token-1" to almostExpiredExpiry, "token-2" to futureExpiry)
+            val appAuth = auth(client)
+
+            val first = appAuth.getInstallationToken()
+            val second = appAuth.getInstallationToken()
+
+            assertEquals("token-1", first)
+            assertEquals("token-2", second)
+            assertEquals(2, callCount())
+        }
+}

--- a/src/test/kotlin/no/nav/security/IntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/IntegrationTest.kt
@@ -5,148 +5,160 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import no.nav.security.kafka.GithubRepoStats
 import no.nav.security.mocks.*
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
 
 class IntegrationTest {
-    
     @Test
-    fun `fetchRepositoryStats produces correct kafka and bigquery output`() = runBlocking {
-        val mockGithub = MockGitHub()
-        val mockNaisApi = MockNaisApi()
-        val mockTeamcatalog = MockTeamcatalog()
-        val mockBqRepo = MockBigQueryRepos()
-        val mockBqTeam = MockBigQueryTeams()
-        val mockBqVuln = MockBigQueryVulnerabilities()
-        val mockKafka = MockKafkaProducer()
-        
-        val deps = AppDependencies(
-            github = mockGithub,
-            githubHttpClient = HttpClient(),
-            naisApi = mockNaisApi,
-            teamcatalog = mockTeamcatalog,
-            bqRepo = mockBqRepo,
-            bqTeam = mockBqTeam,
-            bqVulnerabilities = mockBqVuln,
-            kafkaProducer = mockKafka
-        )
-        
-        fetchRepositoryStats(deps)
-        
-        assertTrue(mockGithub.fetchOrgRepositoriesCalled)
-        assertTrue(mockNaisApi.teamStatsCalled)
-        assertTrue(mockNaisApi.deploymentsCalled)
-        assertTrue(mockTeamcatalog.updateRecordsCalled)
-        assertTrue(mockBqRepo.insertCalled)
-        assertTrue(mockBqRepo.fetchDeploymentsCalled)
-        assertTrue(mockBqTeam.insertCalled)
-        
-        assertEquals(2, mockBqRepo.insertedRecords.size)
-        mockBqRepo.insertedRecords.forEach { record ->
-            assertFalse(record.repositoryName.contains("/"), 
-                "BigQuery repositoryName should not contain org: ${record.repositoryName}")
+    fun `fetchRepositoryStats produces correct kafka and bigquery output`() =
+        runBlocking {
+            val mockGithub = MockGitHub()
+            val mockNaisApi = MockNaisApi()
+            val mockTeamcatalog = MockTeamcatalog()
+            val mockBqRepo = MockBigQueryRepos()
+            val mockBqTeam = MockBigQueryTeams()
+            val mockBqVuln = MockBigQueryVulnerabilities()
+            val mockKafka = MockKafkaProducer()
+
+            val deps =
+                AppDependencies(
+                    github = mockGithub,
+                    githubHttpClient = HttpClient(),
+                    naisApi = mockNaisApi,
+                    teamcatalog = mockTeamcatalog,
+                    bqRepo = mockBqRepo,
+                    bqTeam = mockBqTeam,
+                    bqVulnerabilities = mockBqVuln,
+                    kafkaProducer = mockKafka,
+                )
+
+            fetchRepositoryStats(deps)
+
+            assertTrue(mockGithub.fetchOrgRepositoriesCalled)
+            assertTrue(mockNaisApi.teamStatsCalled)
+            assertTrue(mockNaisApi.deploymentsCalled)
+            assertTrue(mockTeamcatalog.updateRecordsCalled)
+            assertTrue(mockBqRepo.insertCalled)
+            assertTrue(mockBqRepo.fetchDeploymentsCalled)
+            assertTrue(mockBqTeam.insertCalled)
+
+            assertEquals(2, mockBqRepo.insertedRecords.size)
+            mockBqRepo.insertedRecords.forEach { record ->
+                assertFalse(
+                    record.repositoryName.contains("/"),
+                    "BigQuery repositoryName should not contain org: ${record.repositoryName}",
+                )
+            }
+            assertEquals("test-repo-one", mockBqRepo.insertedRecords[0].repositoryName)
+            assertEquals("test-repo-two", mockBqRepo.insertedRecords[1].repositoryName)
+
+            assertEquals(2, mockKafka.produceCalled)
+            assertEquals(2, mockKafka.producedMessages.size)
+
+            mockKafka.producedMessages.forEach { message ->
+                val parsed = Json.decodeFromString<GithubRepoStats>(message)
+                assertTrue(
+                    parsed.repositoryName.contains("/"),
+                    "Kafka repositoryName should contain org: ${parsed.repositoryName}",
+                )
+            }
+
+            val firstKafkaMessage = Json.decodeFromString<GithubRepoStats>(mockKafka.producedMessages[0])
+            assertEquals("testorg/test-repo-one", firstKafkaMessage.repositoryName)
+            assertTrue(firstKafkaMessage.naisTeams.contains("team-alpha"))
+
+            assertEquals(2, mockBqTeam.insertedRecords.size)
+            assertTrue(mockBqTeam.insertedRecords.any { it.naisTeam == "team-alpha" })
+            assertTrue(mockBqTeam.insertedRecords.any { it.naisTeam == "team-beta" })
         }
-        assertEquals("test-repo-one", mockBqRepo.insertedRecords[0].repositoryName)
-        assertEquals("test-repo-two", mockBqRepo.insertedRecords[1].repositoryName)
-        
-        assertEquals(2, mockKafka.produceCalled)
-        assertEquals(2, mockKafka.producedMessages.size)
-        
-        mockKafka.producedMessages.forEach { message ->
-            val parsed = Json.decodeFromString<GithubRepoStats>(message)
-            assertTrue(parsed.repositoryName.contains("/"), 
-                "Kafka repositoryName should contain org: ${parsed.repositoryName}")
-        }
-        
-        val firstKafkaMessage = Json.decodeFromString<GithubRepoStats>(mockKafka.producedMessages[0])
-        assertEquals("testorg/test-repo-one", firstKafkaMessage.repositoryName)
-        assertTrue(firstKafkaMessage.naisTeams.contains("team-alpha"))
-        
-        assertEquals(2, mockBqTeam.insertedRecords.size)
-        assertTrue(mockBqTeam.insertedRecords.any { it.naisTeam == "team-alpha" })
-        assertTrue(mockBqTeam.insertedRecords.any { it.naisTeam == "team-beta" })
-    }
-    
+
     @Test
-    fun `fetchVulnerabilities produces correct kafka and bigquery output`() = runBlocking {
-        val mockGithub = MockGitHub()
-        val mockNaisApi = MockNaisApi()
-        val mockTeamcatalog = MockTeamcatalog()
-        val mockBqRepo = MockBigQueryRepos()
-        val mockBqTeam = MockBigQueryTeams()
-        val mockBqVuln = MockBigQueryVulnerabilities()
-        val mockKafka = MockKafkaProducer()
-        
-        val deps = AppDependencies(
-            github = mockGithub,
-            githubHttpClient = HttpClient(),
-            naisApi = mockNaisApi,
-            teamcatalog = mockTeamcatalog,
-            bqRepo = mockBqRepo,
-            bqTeam = mockBqTeam,
-            bqVulnerabilities = mockBqVuln,
-            kafkaProducer = mockKafka
-        )
-        
-        fetchVulnerabilities(deps)
-        
-        assertTrue(mockGithub.fetchRepositoryVulnerabilitiesCalled)
-        assertTrue(mockNaisApi.repoVulnerabilitiesCalled)
-        assertTrue(mockBqVuln.insertCalled)
-        
-        assertEquals(1, mockKafka.produceCalled)
-        assertEquals(1, mockKafka.producedMessages.size)
-        
-        val kafkaMessage = Json.decodeFromString<GithubRepoStats>(mockKafka.producedMessages[0])
-        assertEquals("testorg/test-repo-one", kafkaMessage.repositoryName)
-        assertTrue(kafkaMessage.repositoryName.contains("/"), 
-            "Kafka message should use nameWithOwner format")
-        assertEquals(1, kafkaMessage.vulnerabilities.size)
-        assertEquals("HIGH", kafkaMessage.vulnerabilities[0].severity)
-        assertEquals("CVE-2024-0001", kafkaMessage.vulnerabilities[0].identifiers[0].value)
-        
-        assertTrue(mockBqVuln.insertedCount > 0)
-    }
-    
+    fun `fetchVulnerabilities produces correct kafka and bigquery output`() =
+        runBlocking {
+            val mockGithub = MockGitHub()
+            val mockNaisApi = MockNaisApi()
+            val mockTeamcatalog = MockTeamcatalog()
+            val mockBqRepo = MockBigQueryRepos()
+            val mockBqTeam = MockBigQueryTeams()
+            val mockBqVuln = MockBigQueryVulnerabilities()
+            val mockKafka = MockKafkaProducer()
+
+            val deps =
+                AppDependencies(
+                    github = mockGithub,
+                    githubHttpClient = HttpClient(),
+                    naisApi = mockNaisApi,
+                    teamcatalog = mockTeamcatalog,
+                    bqRepo = mockBqRepo,
+                    bqTeam = mockBqTeam,
+                    bqVulnerabilities = mockBqVuln,
+                    kafkaProducer = mockKafka,
+                )
+
+            fetchVulnerabilities(deps)
+
+            assertTrue(mockGithub.fetchRepositoryVulnerabilitiesCalled)
+            assertTrue(mockNaisApi.repoVulnerabilitiesCalled)
+            assertTrue(mockBqVuln.insertCalled)
+
+            assertEquals(1, mockKafka.produceCalled)
+            assertEquals(1, mockKafka.producedMessages.size)
+
+            val kafkaMessage = Json.decodeFromString<GithubRepoStats>(mockKafka.producedMessages[0])
+            assertEquals("testorg/test-repo-one", kafkaMessage.repositoryName)
+            assertTrue(
+                kafkaMessage.repositoryName.contains("/"),
+                "Kafka message should use nameWithOwner format",
+            )
+            assertEquals(1, kafkaMessage.vulnerabilities.size)
+            assertEquals("HIGH", kafkaMessage.vulnerabilities[0].severity)
+            assertEquals("CVE-2024-0001", kafkaMessage.vulnerabilities[0].identifiers[0].value)
+
+            assertTrue(mockBqVuln.insertedCount > 0)
+        }
+
     @Test
-    fun `verify bigquery and kafka use different repository name formats`() = runBlocking {
-        val mockGithub = MockGitHub()
-        val mockNaisApi = MockNaisApi()
-        val mockTeamcatalog = MockTeamcatalog()
-        val mockBqRepo = MockBigQueryRepos()
-        val mockBqTeam = MockBigQueryTeams()
-        val mockBqVuln = MockBigQueryVulnerabilities()
-        val mockKafka = MockKafkaProducer()
-        
-        val deps = AppDependencies(
-            github = mockGithub,
-            githubHttpClient = HttpClient(),
-            naisApi = mockNaisApi,
-            teamcatalog = mockTeamcatalog,
-            bqRepo = mockBqRepo,
-            bqTeam = mockBqTeam,
-            bqVulnerabilities = mockBqVuln,
-            kafkaProducer = mockKafka
-        )
-        
-        fetchRepositoryStats(deps)
-        
-        val bqRepoNames = mockBqRepo.insertedRecords.map { it.repositoryName }
-        val kafkaRepoNames = mockKafka.producedMessages.map { 
-            Json.decodeFromString<GithubRepoStats>(it).repositoryName 
+    fun `verify bigquery and kafka use different repository name formats`() =
+        runBlocking {
+            val mockGithub = MockGitHub()
+            val mockNaisApi = MockNaisApi()
+            val mockTeamcatalog = MockTeamcatalog()
+            val mockBqRepo = MockBigQueryRepos()
+            val mockBqTeam = MockBigQueryTeams()
+            val mockBqVuln = MockBigQueryVulnerabilities()
+            val mockKafka = MockKafkaProducer()
+
+            val deps =
+                AppDependencies(
+                    github = mockGithub,
+                    githubHttpClient = HttpClient(),
+                    naisApi = mockNaisApi,
+                    teamcatalog = mockTeamcatalog,
+                    bqRepo = mockBqRepo,
+                    bqTeam = mockBqTeam,
+                    bqVulnerabilities = mockBqVuln,
+                    kafkaProducer = mockKafka,
+                )
+
+            fetchRepositoryStats(deps)
+
+            val bqRepoNames = mockBqRepo.insertedRecords.map { it.repositoryName }
+            val kafkaRepoNames =
+                mockKafka.producedMessages.map {
+                    Json.decodeFromString<GithubRepoStats>(it).repositoryName
+                }
+
+            bqRepoNames.forEach { name ->
+                assertFalse(name.contains("/"), "BigQuery should not have org prefix: $name")
+            }
+
+            kafkaRepoNames.forEach { name ->
+                assertTrue(name.contains("/"), "Kafka should have org prefix: $name")
+            }
+
+            assertTrue(bqRepoNames.contains("test-repo-one"))
+            assertTrue(bqRepoNames.contains("test-repo-two"))
+            assertTrue(kafkaRepoNames.contains("testorg/test-repo-one"))
+            assertTrue(kafkaRepoNames.contains("testorg/test-repo-two"))
         }
-        
-        bqRepoNames.forEach { name ->
-            assertFalse(name.contains("/"), "BigQuery should not have org prefix: $name")
-        }
-        
-        kafkaRepoNames.forEach { name ->
-            assertTrue(name.contains("/"), "Kafka should have org prefix: $name")
-        }
-        
-        assertTrue(bqRepoNames.contains("test-repo-one"))
-        assertTrue(bqRepoNames.contains("test-repo-two"))
-        assertTrue(kafkaRepoNames.contains("testorg/test-repo-one"))
-        assertTrue(kafkaRepoNames.contains("testorg/test-repo-two"))
-    }
 }


### PR DESCRIPTION
Fixes token expiry mid-run causing all team fetches to fail with a masked 401.

- `GitHubAppAuth` now caches the token and proactively refreshes when <5 min remain
- `HttpSend` plugin calls `getInstallationToken()` before every request instead of once at startup
- Added explicit HTTP status checks before deserializing response bodies throughout
